### PR TITLE
Add `noYield` function

### DIFF
--- a/packages/time/src/__tests__/noYield.test.lua
+++ b/packages/time/src/__tests__/noYield.test.lua
@@ -1,0 +1,56 @@
+local noYield = require('../noYield')
+
+local jestGlobals = require('@pkg/@jsdotlua/jest-globals')
+
+local expect = jestGlobals.expect
+local jest = jestGlobals.jest
+local it = jestGlobals.it
+local describe = jestGlobals.describe
+
+it('calls functions normally', function()
+    local testFnMock, testFn = jest.fn(function()
+        return 'success'
+    end)
+
+    local result = noYield(testFn, 5, false, 6)
+
+    expect(testFnMock).toHaveBeenCalledTimes(1)
+    expect(testFnMock).toHaveBeenCalledWith(5, false, 6)
+    expect(result).toBe('success')
+end)
+
+if _G.DEV then
+    describe('with DEV=true', function()
+        it('throws on yield', function()
+            local _testFnMock, testFn = jest.fn(function(d)
+                task.wait(d)
+            end)
+
+            expect(function()
+                noYield(testFn, 0.1)
+            end).toThrow('function is not allowed to yield')
+        end)
+
+        it('propagates error messages', function()
+            local _testFnMock, testFn = jest.fn(function()
+                error('oof')
+            end)
+
+            expect(function()
+                noYield(testFn, 0.1)
+            end).toThrow('oof')
+        end)
+    end)
+else
+    describe('with DEV=false', function()
+        it('does not throw on yield', function()
+            local _testFnMock, testFn = jest.fn(function(d)
+                task.wait(d)
+            end)
+
+            expect(function()
+                noYield(testFn, 0.1)
+            end).never.toThrow('function is not allowed to yield')
+        end)
+    end)
+end

--- a/packages/time/src/init.lua
+++ b/packages/time/src/init.lua
@@ -1,9 +1,11 @@
 local debounce = require('./debounce')
 local loopUntil = require('./loopUntil')
+local noYield = require('./noYield')
 local throttle = require('./throttle')
 
 return {
     debounce = debounce,
     loopUntil = loopUntil,
+    noYield = noYield,
     throttle = throttle,
 }

--- a/packages/time/src/noYield.lua
+++ b/packages/time/src/noYield.lua
@@ -1,0 +1,28 @@
+local function noYield<T..., R...>(fn: (T...) -> R..., ...: T...): R...
+    if _G.DEV then
+        local thread = coroutine.create(fn)
+
+        local results = table.pack(coroutine.resume(thread, ...))
+
+        local success = results[1]
+        if not success then
+            local err = results[2]
+
+            local message = if typeof(err) == 'string'
+                then debug.traceback(thread, err)
+                else tostring(err)
+
+            error(message, 2)
+        end
+
+        if coroutine.status(thread) ~= 'dead' then
+            error(debug.traceback(thread, 'function is not allowed to yield'), 2)
+        end
+
+        return table.unpack(results :: any, 2)
+    else
+        return fn(...)
+    end
+end
+
+return noYield


### PR DESCRIPTION
`noYield` makes sure that the given function will not yield during its execution. If it does, it will throw an error if dev mode is enabled (using the _G.DEV global variable)
