### PR TITLE
Add RefreshScheduler class to time package

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -2,7 +2,8 @@
   "languageMode": "strict",
   "lintErrors": true,
   "lint": {
-    "*": true
+    "*": true,
+    "LocalShadow": false
   },
   "aliases": {
     "pkg": "./node_modules/.luau-aliases"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ npm install @aceworks-studio/math @aceworks-studio/string @aceworks-studio/time
 
 - [`math` documentation](./packages/math/README.md#content)
 - [`random` documentation](./packages/random/README.md#content)
+- [`state-machine` documentation](./packages/state-machine/README.md#content)
 - [`string` documentation](./packages/string/README.md#content)
 - [`time` documentation](./packages/time/README.md#content)
 

--- a/packages/time/CHANGELOG.md
+++ b/packages/time/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- add `RefreshScheduler` class ([#23](https://github.com/Aceworks-Studio/roblox-utils/pull/23))
+
 ## 0.2.1
 
 - fix `throttle` function ([#11](https://github.com/Aceworks-Studio/roblox-utils/pull/11))

--- a/packages/time/package.json
+++ b/packages/time/package.json
@@ -10,13 +10,19 @@
     "url": "git+https://github.com/Aceworks-Studio/roblox-utils.git",
     "directory": "packages/time"
   },
-  "main": "src/init.lua",
-  "devDependencies": {
-    "@jsdotlua/jest": "^3.6.1-rc.2",
-    "@jsdotlua/jest-globals": "^3.6.1-rc.2"
-  },
   "keywords": [
     "luau",
     "roblox"
-  ]
+  ],
+  "main": "src/init.lua",
+  "dependencies": {
+    "@aceworks-studio/math": "workspace:^",
+    "luau-disk": "^0.1.1",
+    "luau-signal": "^0.1.1",
+    "luau-teardown": "^0.1.4"
+  },
+  "devDependencies": {
+    "@jsdotlua/jest": "^3.6.1-rc.2",
+    "@jsdotlua/jest-globals": "^3.6.1-rc.2"
+  }
 }

--- a/packages/time/src/RefreshScheduler.lua
+++ b/packages/time/src/RefreshScheduler.lua
@@ -1,0 +1,447 @@
+local Disk = require('@pkg/luau-disk')
+local Math = require('@pkg/@aceworks-studio/math')
+local Signal = require('@pkg/luau-signal')
+local Teardown = require('@pkg/luau-teardown')
+
+local loopWhile = require('./loopWhile')
+
+type Signal<T...> = Signal.Signal<T...>
+
+local Array = Disk.Array
+
+export type RefreshScheduler<Request, Result> = {
+    getResult: (self: RefreshScheduler<Request, Result>, request: Request) -> Result?,
+    submit: (
+        self: RefreshScheduler<Request, Result>,
+        request: Request,
+        refreshInterval: number?
+    ) -> (),
+    remove: (self: RefreshScheduler<Request, Result>, request: Request) -> (),
+    tick: (self: RefreshScheduler<Request, Result>) -> (),
+    teardown: (self: RefreshScheduler<Request, Result>) -> (),
+    onChange: (
+        self: RefreshScheduler<Request, Result>,
+        callback: (Request, Result) -> ()
+    ) -> () -> (),
+}
+
+export type RefreshSchedulerOptions<Request> = {
+    getKey: ((Request) -> string)?,
+    rateLimitBudget: number,
+    rateLimitInterval: number?,
+    concurrencyBudget: number?,
+    refreshInterval: number?,
+    clock: (() -> number)?,
+    tickInterval: number?,
+    onError: (err: any, request: Request) -> ()?,
+}
+
+type Private<Request, Result> = {
+    _worker: (Request) -> Result,
+    _cache: { [string]: { value: Result } },
+    _threads: { [string]: thread },
+    _newlySubmitted: { [string]: Request },
+    _newlySubmittedQueue: {
+        {
+            key: string,
+            request: Request,
+            refreshInterval: number?,
+        }
+    },
+    _refreshQueue: {
+        {
+            key: string,
+            request: Request,
+            refreshInterval: number,
+            timestamp: number,
+        }
+    },
+    _getKey: ((Request) -> string)?,
+    _rateLimitBudget: number,
+    _incrementRateLimitBudget: { number },
+    _concurrencyBudget: number,
+    _rateLimitInterval: number,
+    _defaultRefreshInterval: number,
+    _clock: () -> number,
+    _disconnect: () -> ()?,
+    _onError: (err: any, request: Request) -> ()?,
+
+    _onChange: Signal<Request, Result>,
+
+    _work: (self: RefreshScheduler<Request, Result>) -> (),
+    _consumeBudget: (self: RefreshScheduler<Request, Result>) -> (),
+    _insertResult: (
+        self: RefreshScheduler<Request, Result>,
+        key: string,
+        request: Request,
+        result: Result
+    ) -> (),
+    _addToRefreshQueue: (
+        self: RefreshScheduler<Request, Result>,
+        key: string,
+        request: Request,
+        refreshInterval: number
+    ) -> (),
+}
+
+type PrivateRefreshScheduler<Request, Result> =
+    RefreshScheduler<Request, Result>
+    & Private<Request, Result>
+
+type RefreshSchedulerStatic = {
+    new: <Request, Result>(
+        worker: (Request) -> Result,
+        options: RefreshSchedulerOptions<Request>
+    ) -> RefreshScheduler<Request, Result>,
+
+    getResult: <Request, Result>(
+        self: RefreshScheduler<Request, Result>,
+        request: Request
+    ) -> Result?,
+    submit: <Request, Result>(
+        self: RefreshScheduler<Request, Result>,
+        request: Request,
+        refreshInterval: number?
+    ) -> (),
+    remove: <Request, Result>(self: RefreshScheduler<Request, Result>, request: Request) -> (),
+    tick: <Request, Result>(self: RefreshScheduler<Request, Result>) -> (),
+    teardown: <Request, Result>(self: RefreshScheduler<Request, Result>) -> (),
+    onChange: <Request, Result>(
+        self: RefreshScheduler<Request, Result>,
+        callback: (Request, Result) -> ()
+    ) -> () -> (),
+
+    _work: <Request, Result>(self: RefreshScheduler<Request, Result>) -> (),
+    _consumeBudget: <Request, Result>(self: RefreshScheduler<Request, Result>) -> (),
+    _insertResult: <Request, Result>(
+        self: RefreshScheduler<Request, Result>,
+        key: string,
+        request: Request,
+        result: Result
+    ) -> (),
+    _addToRefreshQueue: <Request, Result>(
+        self: RefreshScheduler<Request, Result>,
+        key: string,
+        request: Request,
+        refreshInterval: number
+    ) -> (),
+}
+
+local function assertRequestKey(key: unknown)
+    assert(
+        type(key) == 'string',
+        'error using the RefreshScheduler: make sure to provide the "getKey" function to the scheduler options'
+    )
+end
+
+local RefreshScheduler: RefreshSchedulerStatic = {} :: any
+local RefreshSchedulerMetatable = {
+    __index = RefreshScheduler,
+}
+
+function RefreshScheduler.new<Request, Result>(
+    worker: (Request) -> Result,
+    options: RefreshSchedulerOptions<Request>
+): RefreshScheduler<Request, Result>
+    local self: Private<Request, Result> = {
+        _worker = worker,
+        _cache = {},
+        _threads = {},
+        _newlySubmitted = {},
+        _newlySubmittedQueue = {},
+        _refreshQueue = {},
+        _getKey = options.getKey,
+        _rateLimitBudget = options.rateLimitBudget,
+        _incrementRateLimitBudget = {},
+        _concurrencyBudget = options.concurrencyBudget or 1,
+        _rateLimitInterval = options.rateLimitInterval or 60,
+        _defaultRefreshInterval = options.refreshInterval or math.huge,
+        _clock = options.clock or os.clock,
+        _disconnect = nil,
+        _onError = options.onError,
+
+        _onChange = Signal.new(),
+
+        _work = nil :: any,
+        _consumeBudget = nil :: any,
+        _insertResult = nil :: any,
+        _addToRefreshQueue = nil :: any,
+    }
+
+    if options.tickInterval then
+        self._disconnect =
+            Teardown.fn(loopWhile(options.tickInterval, function(_deltaTime: number): boolean
+                (self :: PrivateRefreshScheduler<Request, Result>):tick()
+
+                return true
+            end))
+    end
+
+    return setmetatable(self, RefreshSchedulerMetatable) :: any
+end
+
+function RefreshScheduler:getResult<Request, Result>(request: Request): Result?
+    local self: PrivateRefreshScheduler<Request, Result> = self :: any
+
+    local key: string = if self._getKey then self._getKey(request) else request :: any
+
+    if _G.DEV then
+        assertRequestKey(key)
+    end
+
+    local value = self._cache[key]
+    return if value then value.value else nil
+end
+
+function RefreshScheduler:submit<Request, Result>(request: Request, refreshInterval: number?)
+    local self: PrivateRefreshScheduler<Request, Result> = self :: any
+
+    local key: string = if self._getKey then self._getKey(request) else request :: any
+
+    if _G.DEV then
+        assertRequestKey(key)
+        assert(
+            refreshInterval == nil or refreshInterval ~= 0,
+            'attempt to use a refreshInterval of 0'
+        )
+        assert(
+            refreshInterval == nil or refreshInterval > 0,
+            'attempt to use a negative refreshInterval'
+        )
+    end
+
+    if self._cache[key] ~= nil or self._threads[key] ~= nil or self._newlySubmitted[key] ~= nil then
+        return
+    end
+
+    local actualRefreshInterval = refreshInterval or self._defaultRefreshInterval
+
+    self._newlySubmitted[key] = request
+    table.insert(self._newlySubmittedQueue, {
+        key = key,
+        request = request,
+        refreshInterval = if Math.isFinite(actualRefreshInterval)
+            then actualRefreshInterval
+            else nil,
+    })
+end
+
+function RefreshScheduler:remove<Request, Result>(request: Request)
+    local self: PrivateRefreshScheduler<Request, Result> = self :: any
+
+    local key: string = if self._getKey then self._getKey(request) else request :: any
+
+    if _G.DEV then
+        assertRequestKey(key)
+    end
+
+    local existingThread = self._threads[key]
+    local existingRequest = self._newlySubmitted[key]
+
+    self._cache[key] = nil
+    self._threads[key] = nil
+    self._newlySubmitted[key] = nil
+
+    if existingRequest then
+        for i, work in self._newlySubmittedQueue do
+            if work.key == key then
+                table.remove(self._newlySubmittedQueue, i)
+                break
+            end
+        end
+    end
+
+    for i, work in self._refreshQueue do
+        if work.key == key then
+            table.remove(self._refreshQueue, i)
+            break
+        end
+    end
+
+    if existingThread then
+        if coroutine.status(existingThread) ~= 'dead' then
+            self._concurrencyBudget += 1
+        end
+        task.cancel(existingThread)
+    end
+end
+
+function RefreshScheduler:tick<Request, Result>()
+    local self: PrivateRefreshScheduler<Request, Result> = self :: any
+
+    local currentTime = self._clock()
+
+    local removeCount = 0
+    for _, timestamps in self._incrementRateLimitBudget do
+        if timestamps < currentTime then
+            self._rateLimitBudget += 1
+            removeCount += 1
+        else
+            break
+        end
+    end
+
+    self._incrementRateLimitBudget = Array.popFirst(self._incrementRateLimitBudget, removeCount)
+
+    -- selene: allow(empty_loop)
+    repeat
+    until not self:_work()
+end
+
+function RefreshScheduler:teardown<Request, Result>()
+    local self: PrivateRefreshScheduler<Request, Result> = self :: any
+
+    local threads = self._threads
+    local disconnect = self._disconnect
+
+    self._cache = {}
+    self._threads = {}
+    self._newlySubmitted = {}
+    self._disconnect = nil
+
+    for _, thread in threads do
+        task.cancel(thread)
+    end
+
+    if disconnect then
+        disconnect()
+    end
+end
+
+function RefreshScheduler:onChange<Request, Result>(callback: (Request, Result) -> ()): () -> ()
+    local self: PrivateRefreshScheduler<Request, Result> = self :: any
+
+    return self._onChange:connect(callback):disconnectOnceFn()
+end
+
+function RefreshScheduler:_work<Request, Result>(): boolean
+    local self: PrivateRefreshScheduler<Request, Result> = self :: any
+
+    if self._rateLimitBudget == 0 or self._concurrencyBudget == 0 then
+        return false
+    end
+
+    for _, work in self._newlySubmittedQueue do
+        local key = work.key
+
+        if self._threads[key] == nil then
+            self:_consumeBudget()
+
+            local thread = task.defer(function()
+                local success, result = pcall(self._worker, work.request)
+
+                self._concurrencyBudget += 1
+                self._threads[key] = nil
+
+                local index = table.find(self._newlySubmittedQueue, work)
+                local queuedItem = if index
+                    then table.remove(self._newlySubmittedQueue, index)
+                    else nil
+
+                if success then
+                    self._newlySubmitted[key] = nil
+
+                    self:_insertResult(key, work.request, result)
+
+                    if work.refreshInterval then
+                        self:_addToRefreshQueue(key, work.request, work.refreshInterval)
+                    end
+                else
+                    if queuedItem then
+                        table.insert(self._newlySubmittedQueue, queuedItem)
+                    end
+                    if self._onError then
+                        self._onError(result, work.request)
+                    end
+                end
+            end)
+
+            self._threads[key] = thread
+
+            return true
+        end
+    end
+
+    local currentTime = self._clock()
+
+    for i, work in self._refreshQueue do
+        if work.timestamp <= currentTime then
+            local key = work.key
+
+            if self._threads[key] == nil then
+                self:_consumeBudget()
+
+                local thread = task.defer(function()
+                    local success, result = pcall(self._worker, work.request)
+
+                    self._concurrencyBudget += 1
+                    self._threads[key] = nil
+
+                    if success then
+                        self:_insertResult(key, work.request, result)
+                        self:_addToRefreshQueue(key, work.request, work.refreshInterval)
+                    elseif _G.DEV then
+                        warn(tostring(result))
+                    end
+                end)
+
+                self._threads[key] = thread
+
+                table.remove(self._refreshQueue, i)
+
+                return true
+            end
+        else
+            break
+        end
+    end
+
+    return false
+end
+
+function RefreshScheduler:_consumeBudget<Request, Result>()
+    local self: PrivateRefreshScheduler<Request, Result> = self :: any
+
+    self._concurrencyBudget -= 1
+    self._rateLimitBudget -= 1
+    table.insert(self._incrementRateLimitBudget, self._clock() + self._rateLimitInterval)
+end
+
+function RefreshScheduler:_insertResult<Request, Result>(key: string, request: Request, result: Result)
+    local self: PrivateRefreshScheduler<Request, Result> = self :: any
+
+    local current = self._cache[key]
+    if current == nil or current.value ~= result then
+        self._cache[key] = { value = result }
+        self._onChange:fire(request, result)
+    end
+end
+
+function RefreshScheduler:_addToRefreshQueue<Request, Result>(key: string, request: Request, refreshInterval: number)
+    local self: PrivateRefreshScheduler<Request, Result> = self :: any
+
+    local timestamp = self._clock() + refreshInterval
+
+    local found = nil
+    for i, work in self._refreshQueue do
+        if work.timestamp > timestamp then
+            found = i
+            break
+        end
+    end
+
+    local work = {
+        key = key,
+        request = request,
+        timestamp = timestamp,
+        refreshInterval = refreshInterval,
+    }
+
+    if found then
+        table.insert(self._refreshQueue, found, work)
+    else
+        table.insert(self._refreshQueue, work)
+    end
+end
+
+return RefreshScheduler

--- a/packages/time/src/__tests__/RefreshScheduler.test.lua
+++ b/packages/time/src/__tests__/RefreshScheduler.test.lua
@@ -1,0 +1,256 @@
+local jestGlobals = require('@pkg/@jsdotlua/jest-globals')
+
+local expect = jestGlobals.expect
+local it = jestGlobals.it
+local describe = jestGlobals.describe
+local beforeEach = jestGlobals.beforeEach
+local jest = jestGlobals.jest
+
+local RefreshScheduler = require('../RefreshScheduler')
+
+describe('deferred tonumber scheduler', function()
+    local clockMock
+    local workFn
+    local scheduler
+    local onError
+
+    beforeEach(function()
+        clockMock = jest.fn()
+        workFn = jest.fn(tonumber)
+        onError = jest.fn(function(request, err)
+            error(`uncaught error while working on request '{request}': {err}`)
+        end)
+        scheduler = RefreshScheduler.new(function(value: string)
+            return workFn(value)
+        end, {
+            rateLimitBudget = 10,
+            clock = clockMock,
+            onError = onError,
+        })
+    end)
+
+    it('never submitted work has no result', function()
+        expect(scheduler:getResult('12')).toEqual(nil)
+    end)
+
+    it('submitted work is not immediately scheduled', function()
+        local request = '12'
+        scheduler:submit(request)
+        expect(scheduler:getResult(request)).toEqual(nil)
+    end)
+
+    it('submitted work is scheduled when there is budget after a tick', function()
+        local request = '12'
+        scheduler:submit(request)
+        clockMock.mockReturnValue(1)
+
+        scheduler:tick()
+        task.wait()
+
+        expect(scheduler:getResult(request)).toEqual(12)
+    end)
+
+    it('submitted work can be cancelled before execution', function()
+        local request = '12'
+        scheduler:submit(request)
+        clockMock.mockReturnValue(1)
+
+        scheduler:tick()
+        scheduler:remove(request)
+        task.wait()
+
+        expect(scheduler:getResult(request)).toEqual(nil)
+    end)
+
+    it('submitted work can be cancelled after execution', function()
+        local request = '12'
+        scheduler:submit(request)
+        clockMock.mockReturnValue(1)
+
+        scheduler:tick()
+        task.wait()
+
+        expect(scheduler:getResult(request)).toEqual(12)
+        scheduler:remove(request)
+        expect(scheduler:getResult(request)).toEqual(nil)
+    end)
+
+    it('submitted work is refreshed after its refresh interval', function()
+        local request = '12'
+        local refreshInterval = 20
+        scheduler:submit(request, refreshInterval)
+        clockMock.mockReturnValue(1)
+
+        scheduler:tick()
+        task.wait()
+
+        expect(workFn).toHaveBeenCalledTimes(1)
+        expect(scheduler:getResult(request)).toEqual(12)
+
+        local refreshedResult = 500
+        workFn.mockReturnValue(refreshedResult)
+        clockMock.mockReturnValue(refreshInterval + 1)
+
+        scheduler:tick()
+        task.wait()
+
+        expect(workFn).toHaveBeenCalledTimes(2)
+        expect(scheduler:getResult(request)).toEqual(refreshedResult)
+    end)
+
+    it('enforces the concurrency budget', function()
+        local request1 = '50'
+        local request2 = '60'
+        scheduler:submit(request1)
+        scheduler:submit(request2)
+
+        clockMock.mockReturnValue(1)
+        scheduler:tick()
+        task.wait()
+
+        expect(scheduler:getResult(request1)).toEqual(50)
+        expect(scheduler:getResult(request2)).toEqual(nil)
+
+        clockMock.mockReturnValue(2)
+        scheduler:tick()
+        task.wait()
+
+        expect(scheduler:getResult(request2)).toEqual(60)
+    end)
+
+    describe('with concurrency', function()
+        beforeEach(function()
+            scheduler = RefreshScheduler.new(function(value: string)
+                return workFn(value)
+            end, {
+                concurrencyBudget = 2,
+                rateLimitBudget = 2,
+                clock = clockMock,
+                onError = function(err, request)
+                    error(`uncaught error while working on request '{request}': {err}`)
+                end,
+            })
+        end)
+
+        it('handles multiple submissions without interference', function()
+            local request1 = '10'
+            local request2 = '20'
+            scheduler:submit(request1)
+            scheduler:submit(request2)
+            clockMock.mockReturnValue(1)
+
+            scheduler:tick()
+            task.wait()
+
+            expect(scheduler:getResult(request1)).toEqual(10)
+            expect(scheduler:getResult(request2)).toEqual(20)
+        end)
+    end)
+
+    describe('tiny rate limit budget', function()
+        local rateLimitInterval = 15
+
+        beforeEach(function()
+            scheduler = RefreshScheduler.new(function(value: string)
+                return workFn(value)
+            end, {
+                concurrencyBudget = 1,
+                rateLimitBudget = 2,
+                rateLimitInterval = rateLimitInterval,
+                clock = clockMock,
+                onError = function(err, request)
+                    error(`uncaught error while working on request '{request}': {err}`)
+                end,
+            })
+        end)
+
+        it('respects rate limit and concurrency budget across multiple ticks', function()
+            local request1 = '30'
+            local request2 = '35'
+            local request3 = '40'
+            scheduler:submit(request1)
+            scheduler:submit(request2)
+            scheduler:submit(request3)
+
+            clockMock.mockReturnValue(1)
+            scheduler:tick()
+            task.wait()
+
+            expect(scheduler:getResult(request1)).toEqual(30)
+
+            clockMock.mockReturnValue(2)
+            scheduler:tick()
+            task.wait()
+
+            expect(scheduler:getResult(request1)).toEqual(30)
+            expect(scheduler:getResult(request2)).toEqual(35)
+            expect(scheduler:getResult(request3)).toEqual(nil)
+
+            clockMock.mockReturnValue(rateLimitInterval - 1)
+            scheduler:tick()
+            task.wait()
+
+            expect(scheduler:getResult(request1)).toEqual(30)
+            expect(scheduler:getResult(request2)).toEqual(35)
+            expect(scheduler:getResult(request3)).toEqual(nil)
+
+            clockMock.mockReturnValue(rateLimitInterval + 10)
+            scheduler:tick()
+            task.wait()
+
+            expect(scheduler:getResult(request1)).toEqual(30)
+            expect(scheduler:getResult(request2)).toEqual(35)
+            expect(scheduler:getResult(request3)).toEqual(40)
+        end)
+    end)
+
+    it('handles errors in worker function gracefully', function()
+        local request = 'error-case'
+        local errorObject = { message = 'simulated error' }
+        -- mock return value to avoid throwing the error in the output
+        onError.mockReturnValue(nil)
+        workFn.mockImplementation(function()
+            error(errorObject)
+        end)
+        scheduler:submit(request)
+        clockMock.mockReturnValue(1)
+
+        scheduler:tick()
+        task.wait()
+
+        expect(scheduler:getResult(request)).toEqual(nil)
+        expect(onError).toHaveBeenCalledWith(errorObject, request)
+    end)
+
+    it('invokes onChange callback when result changes', function()
+        local request = '70'
+        local callback, callbackFn = jest.fn()
+        scheduler:onChange(callbackFn)
+
+        scheduler:submit(request)
+        clockMock.mockReturnValue(1)
+        scheduler:tick()
+        task.wait()
+
+        expect(callback).toHaveBeenCalledWith(request, 70)
+    end)
+
+    it('does not invoke onChange if result is unchanged', function()
+        local request = '80'
+        local callback, callbackFn = jest.fn()
+        scheduler:onChange(callbackFn)
+        local refreshInterval = 100
+        scheduler:submit(request, refreshInterval)
+
+        clockMock.mockReturnValue(1)
+        scheduler:tick()
+        task.wait()
+
+        clockMock.mockReturnValue(refreshInterval + 10)
+        scheduler:tick()
+        task.wait()
+
+        expect(workFn).toHaveBeenCalledTimes(2)
+        expect(callback).toHaveBeenCalledTimes(1)
+    end)
+end)

--- a/packages/time/src/init.lua
+++ b/packages/time/src/init.lua
@@ -1,3 +1,4 @@
+local RefreshScheduler = require('./RefreshScheduler')
 local debounce = require('./debounce')
 local loopUntil = require('./loopUntil')
 local loopWhile = require('./loopWhile')
@@ -5,9 +6,12 @@ local noYield = require('./noYield')
 local throttle = require('./throttle')
 local yieldUntil = require('./yieldUntil')
 
+export type RefreshScheduler<Request, Result> = RefreshScheduler.RefreshScheduler<Request, Result>
+export type RefreshSchedulerOptions<Request> = RefreshScheduler.RefreshSchedulerOptions<Request>
 export type Interval = loopUntil.Interval
 
 return {
+    RefreshScheduler = RefreshScheduler,
     debounce = debounce,
     loopUntil = loopUntil,
     loopWhile = loopWhile,

--- a/scripts/roblox-test.server.lua
+++ b/scripts/roblox-test.server.lua
@@ -11,6 +11,9 @@ local jestRoots = {
         :FindFirstChild('random'),
     ReplicatedStorage:FindFirstChild('node_modules')
         :FindFirstChild('@aceworks-studio')
+        :FindFirstChild('state-machine'),
+    ReplicatedStorage:FindFirstChild('node_modules')
+        :FindFirstChild('@aceworks-studio')
         :FindFirstChild('string'),
     ReplicatedStorage:FindFirstChild('node_modules')
         :FindFirstChild('@aceworks-studio')

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,15 +525,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jsdotlua/path@npm:^3.6.1-rc.2":
-  version: 3.6.1-rc.2
-  resolution: "@jsdotlua/path@npm:3.6.1-rc.2"
-  dependencies:
-    "@jsdotlua/luau-polyfill": "npm:^1.2.6"
-  checksum: 10c0/60868d5161f3bfc263ebcddac8cbe83f6787f85409fc1a563ff350b9ccab05c88e934ccd7e3627ea77bd73f5e30b21dbe7d85e7a4d8445d3baf96cd42bab4877
-  languageName: node
-  linkType: hard
-
 "@jsdotlua/picomatch@npm:^0.4.0":
   version: 0.4.0
   resolution: "@jsdotlua/picomatch@npm:0.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -525,6 +525,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jsdotlua/path@npm:^3.6.1-rc.2":
+  version: 3.6.1-rc.2
+  resolution: "@jsdotlua/path@npm:3.6.1-rc.2"
+  dependencies:
+    "@jsdotlua/luau-polyfill": "npm:^1.2.6"
+  checksum: 10c0/60868d5161f3bfc263ebcddac8cbe83f6787f85409fc1a563ff350b9ccab05c88e934ccd7e3627ea77bd73f5e30b21dbe7d85e7a4d8445d3baf96cd42bab4877
+  languageName: node
+  linkType: hard
+
 "@jsdotlua/picomatch@npm:^0.4.0":
   version: 0.4.0
   resolution: "@jsdotlua/picomatch@npm:0.4.0"
@@ -615,15 +624,6 @@ __metadata:
   version: 0.1.1
   resolution: "luau-disk@npm:0.1.1"
   checksum: 10c0/ee97edfe07671c3989f31b21cdef1001d845dbbc4940b41a2cb9b74e1c1bb0008c339348c595669177884ad8f0df4b6bf14ec66457854edcccb8e18fc3e9e4eb
-  languageName: node
-  linkType: hard
-
-"luau-path@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "luau-path@npm:0.1.0"
-  dependencies:
-    luau-disk: "npm:^0.1.1"
-  checksum: 10c0/bd991ee1ff2e9f2d23a8354f806ef63571e5ab93f3377a76abf72d48da0d16745d905847330fbcb1f52f09765690847b7db1ec91cea23b73edc8921ede7d695d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,8 +49,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@aceworks-studio/time@workspace:packages/time"
   dependencies:
+    "@aceworks-studio/math": "workspace:^"
     "@jsdotlua/jest": "npm:^3.6.1-rc.2"
     "@jsdotlua/jest-globals": "npm:^3.6.1-rc.2"
+    luau-disk: "npm:^0.1.1"
+    luau-signal: "npm:^0.1.1"
+    luau-teardown: "npm:^0.1.4"
   languageName: unknown
   linkType: soft
 
@@ -623,10 +627,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"luau-path@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "luau-path@npm:0.1.0"
+  dependencies:
+    luau-disk: "npm:^0.1.1"
+  checksum: 10c0/bd991ee1ff2e9f2d23a8354f806ef63571e5ab93f3377a76abf72d48da0d16745d905847330fbcb1f52f09765690847b7db1ec91cea23b73edc8921ede7d695d
+  languageName: node
+  linkType: hard
+
 "luau-regexp@npm:^0.2.1":
   version: 0.2.1
   resolution: "luau-regexp@npm:0.2.1"
   checksum: 10c0/7badc4e6f9ab7753d77e49db3012c525fb85dff70930c806754edd86893a39c1afb1aba51aba00b2f456f72d7f02c6a8812a160646a05986bc6d1bfae6251494
+  languageName: node
+  linkType: hard
+
+"luau-signal@npm:^0.1.1":
+  version: 0.1.1
+  resolution: "luau-signal@npm:0.1.1"
+  dependencies:
+    luau-task: "npm:^1.0.1"
+  checksum: 10c0/fbe6dff361946ffca415b4dea4852641c756f3d82161603d8cf0cbb130a8e9b470f67acc03f6cc193affaf4f021801ad8daebceb1f9d600e4d1108c38d3d0380
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add `RefreshScheduler` to time package.

This class can schedule work across time while respecting a rate limit. Additionally, it can also refresh the work based on a specified refresh rate.

- [x] add entry to the changelog
- [x] update docs
