### PR TITLE
Fix SpatialMap position updates within the same cell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: Roblox/setup-foreman@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: CompeyDev/setup-rokit@v0.1.2
 
       - name: Enable corepack
         run: corepack enable

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,7 +1,7 @@
 [tools]
-darklua = { github = "seaofvoices/darklua", version = "=0.14.1"}
-luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.36.0"}
-rojo = { github = "rojo-rbx/rojo", version = "=7.4.1"}
+darklua = { github = "seaofvoices/darklua", version = "=0.16.0"}
+luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.44.1"}
+rojo = { github = "rojo-rbx/rojo", version = "=7.5.1"}
 run-in-roblox = { github = "rojo-rbx/run-in-roblox", version = "=0.3.0"}
-selene = { github = "Kampfkarren/selene", version = "=0.27.1"}
+selene = { github = "Kampfkarren/selene", version = "=0.28.0"}
 stylua = { github = "JohnnyMorganz/StyLua", version = "=0.20.0"}

--- a/packages/spatial-data/CHANGELOG.md
+++ b/packages/spatial-data/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- fix `SpatialMap` position updates that stays within the same cell ([#32](https://github.com/Aceworks-Studio/roblox-utils/pull/32))
+
 ## 0.1.0
 
 - Initial version

--- a/packages/spatial-data/src/SpatialMap.lua
+++ b/packages/spatial-data/src/SpatialMap.lua
@@ -61,6 +61,10 @@ function SpatialMap:add<T>(position: Vector3, item: T): (Vector3) -> ()
             return
         end
 
+        if newPosition then
+            value.position = newPosition
+        end
+
         local newHashPosition = newPosition and self:getMapPosition(newPosition)
 
         if newHashPosition ~= nil and newHashPosition == hashPosition then
@@ -85,7 +89,6 @@ function SpatialMap:add<T>(position: Vector3, item: T): (Vector3) -> ()
 
         if newHashPosition then
             hashPosition = newHashPosition
-            value.position = newPosition :: Vector3
             if self._spaceMap[newHashPosition] == nil then
                 self._spaceMap[newHashPosition] = { value }
             else

--- a/packages/spatial-data/src/__tests__/SpatialMap.test.lua
+++ b/packages/spatial-data/src/__tests__/SpatialMap.test.lua
@@ -48,6 +48,19 @@ describe('getInsideSphere', function()
 
             expect(map:getInsideSphere(awayFromPosition, awayFactor / 2)).toEqual({})
         end)
+
+        it(
+            `creates an item, moves it and get it back from the moved position at ({position})`,
+            function()
+                local item = 'oof'
+
+                local updatePosition = map:add(awayFromPosition, item)
+
+                updatePosition(position)
+
+                expect(map:getInsideSphere(position, 0.5)).toEqual({ item })
+            end
+        )
     end
 end)
 


### PR DESCRIPTION
Position updates in the spatial map were only reflected when they moved across grid cells. Now with this fix, the position is always updated.

- [x] add entry to the changelog
